### PR TITLE
chore: Update bellperson, pasta-msm and pasta_curves dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
-bellperson = { version = "0.25", default-features = false }
+bellperson = { git="https://github.com/lurk-lab/bellperson", branch="dev", default-features = false }
 ff = { version = "0.13.0", features = ["derive"] }
 digest = "0.8.1"
 sha3 = "0.8.2"
@@ -20,8 +20,8 @@ rand_core = { version = "0.6.0", default-features = false }
 rand_chacha = "0.3"
 itertools = "0.9.0"
 subtle = "2.4"
-pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
-neptune = { version = "10.0.0", default-features = false }
+pasta_curves = { git="https://github.com/lurk-lab/pasta_curves", branch="dev", features = ["repr-c", "serde"] }
+neptune = { git="https://github.com/lurk-lab/neptune", branch="dev", default-features = false }
 generic-array = "0.14.4"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
@@ -34,7 +34,7 @@ byteorder = "1.4.3"
 thiserror = "1.0" 
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
-pasta-msm = { version = "0.1.4" }
+pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }
 
 [dev-dependencies]
 criterion = "0.3.1"


### PR DESCRIPTION
- Update `pasta-msm`, `bellperson` and `pasta_curves` dependencies to use `lurk-lab` repository's `dev` branch
- Supersedes #3 