### PR TITLE
Added generating json test for grumpkin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ bincode = "1.2.1"
 flate2 = "1.0"
 bitvec = "1.0"
 byteorder = "1.4.3"
-thiserror = "1.0" 
-halo2curves = { version="0.1.0", features = [ "derive_serde" ] }
+thiserror = "1.0"
+halo2curves = { version="0.6.1", features = [ "derive_serde" ] }
 serde_json = "1.0.111"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1154,7 +1154,7 @@ mod tests {
     test_ivc_nontrivial_with_compression_with::<bn256::Point, grumpkin::Point>(false);
   }
 
-  fn test_ivc_nontrivial_with_spark_compression_with<G1, G2>()
+  fn test_ivc_nontrivial_with_spark_compression_with<G1, G2>(generate_keys_to_json: bool)
   where
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
@@ -1233,6 +1233,11 @@ mod tests {
     assert!(res.is_ok());
     let compressed_snark = res.unwrap();
 
+    if generate_keys_to_json {
+      let serialized_compressed_snark = serde_json::to_string(&compressed_snark).unwrap();std::fs::write(std::path::Path::new("compressed-snark-grumpkin.json"), serialized_compressed_snark).expect("Unable to write file");
+      let vk_serialized = serde_json::to_string(&vk).unwrap();std::fs::write(std::path::Path::new("vk-grumpkin.json"), vk_serialized).expect("Unable to write file");
+    }
+
     // verify the compressed SNARK
     let res = compressed_snark.verify(
       &vk,
@@ -1248,8 +1253,8 @@ mod tests {
     type G1 = pasta_curves::pallas::Point;
     type G2 = pasta_curves::vesta::Point;
 
-    test_ivc_nontrivial_with_spark_compression_with::<G1, G2>();
-    test_ivc_nontrivial_with_spark_compression_with::<bn256::Point, grumpkin::Point>();
+    test_ivc_nontrivial_with_spark_compression_with::<G1, G2>(false);
+    test_ivc_nontrivial_with_spark_compression_with::<bn256::Point, grumpkin::Point>(false);
   }
 
   fn test_ivc_nondet_with_compression_with<G1, G2>()
@@ -1476,7 +1481,7 @@ mod tests {
     test_ivc_base_with::<bn256::Point, grumpkin::Point>();
   }
 
-  // cargo +nightly test test_ivc_nontrivial_with_compression_pasta --release -- --nocapture --ignored
+  // cargo test test_ivc_nontrivial_with_compression_pasta --release -- --nocapture --ignored
   #[test]
   #[ignore]
   fn solidity_compatibility_e2e_pasta() {
@@ -1485,4 +1490,14 @@ mod tests {
 
     test_ivc_nontrivial_with_compression_with::<G1, G2>(true);
   }
+
+  // cargo test solidity_compatibility_e2e_grumpkin --release -- --nocapture --ignored
+  #[test]
+  #[ignore]
+  fn solidity_compatibility_e2e_grumpkin() {
+    type G1 = bn256::Point;
+    type G2 = grumpkin::Point;
+
+    test_ivc_nontrivial_with_spark_compression_with::<G1, G2>(true);
+    }
 }


### PR DESCRIPTION
Added unit test for generating JSON files for the `VerifierKey` and `CompressedSnark` if using Bn256/Grumpkin curve cycle. Will create PR for [grumpkin](https://github.com/lurk-lab/solidity-verifier/tree/grumpkin) branch of solidity-verifier with the script that invokes the test - similar to previous PR for [pasta](https://github.com/lurk-lab/solidity-verifier/tree/pasta) branch. 